### PR TITLE
알림 로직 DTO 추가 및 테스트 코드 수정

### DIFF
--- a/proejct/src/main/java/org/fastcampus/proejct/global/dto/NotificationDto.java
+++ b/proejct/src/main/java/org/fastcampus/proejct/global/dto/NotificationDto.java
@@ -1,0 +1,21 @@
+package org.fastcampus.proejct.global.dto;
+
+import lombok.*;
+
+import java.io.Serializable;
+
+/**
+ * DTO for {@link org.fastcampus.proejct.global.domain.NotificationEntity}
+ */
+@Data
+public class NotificationDto implements Serializable {
+    String notiType;
+    long senderId;
+    long receiverId;
+    String text;
+    long id;
+
+    public NotificationDto () {
+    }
+
+}

--- a/proejct/src/main/java/org/fastcampus/proejct/global/dto/TemplateCollection.java
+++ b/proejct/src/main/java/org/fastcampus/proejct/global/dto/TemplateCollection.java
@@ -1,0 +1,23 @@
+package org.fastcampus.proejct.global.dto;
+
+public class TemplateCollection {
+
+    public enum contentTemplate{
+        FRIEND_ADD("님이 친구추가를 신청하셨습니다."),
+        FRIEND_REJACT("님이 친구추가를 거절하셨습니다."),
+        WORK_ADD("의 할일이 추가되었습니다."),
+        WORK_COMPLETE("의 할일이 완료되었습니다.");
+
+        public String getMessage() {
+            return message;
+        }
+
+        private final String message;
+
+        contentTemplate(String message) {
+            this.message = message;
+        }
+    }
+
+    //공통코드 테이블로 관리하는게 아니니까 알람 발송 타입 정의 enum이 추가 되야 할 것 같아요 ~
+}

--- a/proejct/src/main/java/org/fastcampus/proejct/global/service/NotificationService.java
+++ b/proejct/src/main/java/org/fastcampus/proejct/global/service/NotificationService.java
@@ -1,7 +1,9 @@
 package org.fastcampus.proejct.global.service;
 
 import org.fastcampus.proejct.global.domain.NotificationEntity;
+import org.fastcampus.proejct.global.dto.NotificationDto;
 import org.fastcampus.proejct.global.repository.NotificationRepository;
+import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -11,11 +13,12 @@ import org.springframework.stereotype.Service;
  * @fileName     : NotificationService.java
  * @author       : Jiyong Jung
  * @date         : 2023-10-30 :: 오후 4:29
- * @desc         :
+ * @desc         : 알림 기능 CRUD
  * ===========================================================
  * line                  AUTHOR             NOTE
  * -----------------------------------------------------------
  *   0              Jiyong Jung        최초 생성
+ *   39             Jiyong Jung        args NotificationDTO 받도록 수정
  */
 public class NotificationService {
     @Autowired
@@ -30,13 +33,15 @@ public class NotificationService {
     }
 
     /**
-     * @param notiEntity
+     * @param NotificationDto param
      * @return boolean
      */
-    public boolean setNotice(NotificationEntity notiEntity){
+    public boolean addNotice(NotificationDto param){
         boolean ret = false;
         try{
-            notificationRepository.save(notiEntity);
+            ModelMapper mapper = new ModelMapper();
+            NotificationEntity notice = mapper.map(param,NotificationEntity.class);
+            notificationRepository.save(notice);
             ret = true;
         }catch (Exception e){
             ret = false;

--- a/proejct/src/test/java/org/fastcampus/proejct/global/service/NotificationServiceTest.java
+++ b/proejct/src/test/java/org/fastcampus/proejct/global/service/NotificationServiceTest.java
@@ -1,16 +1,18 @@
 package org.fastcampus.proejct.global.service;
 
-import org.fastcampus.proejct.global.domain.NotificationEntity;
+import org.fastcampus.proejct.global.dto.NotificationDto;
 import org.fastcampus.proejct.global.repository.NotificationRepository;
+import org.fastcampus.proejct.global.dto.TemplateCollection;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.LocalDateTime;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -24,45 +26,48 @@ class NotificationServiceTest {
     @Mock
     private NotificationRepository notiRepository;
 
-    void testGetAllNotice(){
+    @Mock
+    private TemplateCollection temps;
 
-        /* given, 등록 더미 데이터 */
-        Long id = 1L;
+    private static Stream<Arguments> param(){
+        //Long id = 1L;
         String notiType = "addBuddy";
+        long id = 1L;
         long senderId = 1L;
         long receiverId = 1L;
-        String content = senderId + "님이 친구 추가를 요청 하셨습니다.";
-        LocalDateTime createdAt = LocalDateTime.now();
+        String content = senderId + TemplateCollection.contentTemplate.FRIEND_ADD.getMessage();
+
+        NotificationDto dto = new NotificationDto();
+        dto.setId(id);
+        dto.setNotiType(notiType);
+        dto.setSenderId(senderId);
+        dto.setReceiverId(receiverId);
+        dto.setText(content);
+
+        return Stream.of(
+                Arguments.of(dto)
+        );
+    }
+
+
+    void testGetAllNotice(){
 
     }
 
     @DisplayName("알림 등록 테스트")
-    @Test
-    void testAddNotice(){
-        /* given */
-        NotificationEntity notice = new NotificationEntity();
+    @ParameterizedTest
+    @MethodSource("param")
+    void testAddNotice(NotificationDto notiDto){
 
-        Long id = 1L;
-        String notiType = "addBuddy";
-        long senderId = 1L;
-        long receiverId = 1L;
-        String content = senderId + "님이 친구 추가를 요청 하셨습니다.";
-        LocalDateTime createdAt = LocalDateTime.now();
+        /* 시스템 도입시 notiType과 content template 정의해서 별개 파일로 관리 되도록 작업 진행 */
 
-        notice.builder()
-                .notiType(notiType)
-                .senderId(senderId)
-                .receiverId(receiverId)
-                .text(content)
-                .build();
-
+        /* given -- 32line에서 설정 완료 */
 
         /* when */
-        boolean result = notiService.setNotice(notice);
-        System.err.println(result);
+        boolean result = notiService.addNotice(notiDto);
+
         /* then */
         assertTrue(result);
-
 
     }
 


### PR DESCRIPTION
## 작업 내용

<br>
[√] 알림 정보 등록시 DTO -> Entity 넘어가도록 수정
[√] DTO -> Entity 맵핑시 Builder -> ModelMapper 변경
[√] 알림 정보 테스트코드 작성시 param 을 dto로 받고, dto 데이터를 별도로 세팅 가능하도록 수정
<br>

## 참고 사항

<br><br>

## 26
