### PR TITLE
#71 [feat] 게시글 조회 상세 삭제

### DIFF
--- a/proejct/src/main/java/org/fastcampus/proejct/auth/converter/dto/UserPrincipal.java
+++ b/proejct/src/main/java/org/fastcampus/proejct/auth/converter/dto/UserPrincipal.java
@@ -87,6 +87,13 @@ public record UserPrincipal(
     }
 
     /**
+     * 사용자 검증은 id를 가지고 해야합니다. (board.id = userInfo.id)
+     * **/
+    public Long getUserId() {
+        return id;
+    }
+
+    /**
      * User 클래스 상속을 받지 않아 실질적으로 필요가 없다.
      * 게정 만료 여부,
      * 계정 lock 여부,

--- a/proejct/src/main/java/org/fastcampus/proejct/board/controller/BoardController.java
+++ b/proejct/src/main/java/org/fastcampus/proejct/board/controller/BoardController.java
@@ -33,7 +33,7 @@ public class BoardController {
         List<BoardDto> boards = boardService.getBoards(userPrincipal.id());
         List<NotificationDto> notifications = notificationService.getAllNotice();
         model.addAttribute("boards", boards);
-        model.addAttribute("username", userPrincipal.getUsername());
+        model.addAttribute("userId", userPrincipal.getUserId());
         model.addAttribute("notifications", notifications);
         return "tables";
     }
@@ -53,28 +53,19 @@ public class BoardController {
     }
 
     @GetMapping("/board/{id}")
-    public String getBoardDetail(@PathVariable Long id, Model model) {
+    public String getBoardDetail(@PathVariable Long id, Model model,@AuthenticationPrincipal UserPrincipal userPrincipal) {
         BoardDto board = boardService.getBoard(id);
         model.addAttribute("board", board);
+        model.addAttribute("userId", userPrincipal.getUserId());
         return "board/detail";
     }
 
     @GetMapping("/board/{id}/update")
-    public String getBoardUpdate(@PathVariable Long id, Model model) {
+    public String getBoardUpdate(@PathVariable Long id, Model model, @AuthenticationPrincipal UserPrincipal userPrincipal) {
         BoardDto board = boardService.getBoard(id);
         model.addAttribute("board", board);
+        model.addAttribute("userId", userPrincipal.getUserId());
         return "board/write";
     }
 
-    @PostMapping("/board/{id}/update")
-    public String postBoardUpdate(@PathVariable Long id, BoardDto board) {
-        boardService.updateBoard(id, board);
-        return "redirect:/board";
-    }
-
-    @GetMapping("/board/{id}/delete")
-    public String deleteBoard(@PathVariable Long id) {
-        boardService.deleteBoard(id);
-        return "redirect:/board";
-    }
 }

--- a/proejct/src/main/java/org/fastcampus/proejct/board/controller/BoardRestController.java
+++ b/proejct/src/main/java/org/fastcampus/proejct/board/controller/BoardRestController.java
@@ -44,4 +44,17 @@ public class BoardRestController {
         // TODO: 11/6/23 유저가 해당 게시물을 완료처리할 수 있는지 확인 프론트에서 보여주는 화면을 달리하는게 맞는듯 ㅇㅇ
         return false;
     }
+
+
+    @PutMapping("/board/{id}/update")
+    public String postBoardUpdate(@PathVariable Long id, BoardDto board) {
+        boardService.updateBoard(id, board);
+        return "redirect:/board";
+    }
+
+    @DeleteMapping("/board/{id}/delete")
+    public String deleteBoard(@PathVariable Long id) {
+        boardService.deleteBoard(id);
+        return "redirect:/board";
+    }
 }

--- a/proejct/src/main/resources/templates/board/detail.html
+++ b/proejct/src/main/resources/templates/board/detail.html
@@ -5,25 +5,57 @@
     <title>게시물 상세</title>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
 </head>
+<script src="https://code.jquery.com/jquery-3.7.1.js" integrity="sha256-eKhayi8LEQwp4NKxN+CfCh+3qOVUtJn3QNZ0TciWLP4=" crossorigin="anonymous"></script>
+<script>
+    $().ready(function () {
+        $("#update").on("click",function(){
+            $("#frm").attr("action","/board" + $("#board_id").val() + "/update");
+            $("#frm").submit();
+        });
+
+        $("#delete").on("click",function(){
+
+            var delComfirm = confirm("게시글을 삭제 하시겠습니까?")
+            if(delComfirm){
+                $.ajax({
+                    url: '/board/' + $("#board_id").val()+'/delete',
+                    type: 'DELETE',
+                    contentType: 'application/json',
+                    success: function(response) {
+                        alert("정상 삭제 되었습니다.");
+                        location.replace("/board");
+                    },
+                    error: function(xhr, status, error) {
+                        alert("에러가 발생했습니다 관리자에게 문의하세요");
+                    }
+                });
+            }
+        });
+    });
+
+</script>
 <body>
 <div class="container">
     <header>
         <h1>게시물 상세</h1>
     </header>
     <main>
-        <div class="card">
-            <div class="card-header">
-                <h2 th:text="${board.title}">제목</h2>
-                <p th:text="${board.userInfo().name()}">작성자</p>
-                <p th:date="${board.createdAt()}">작성일</p>
+        <form id="frm" name="frm">
+            <input type="hidden" th:value="${board.id}" id="board_id">
+            <div class="card">
+                <div class="card-header">
+                    <h2 th:text="${board.title}">제목</h2>
+                    <p th:text="${board.userInfo().name()}">작성자</p>
+                    <p th:date="${board.createdAt()}">작성일</p>
+                </div>
+                <div class="card-body" th:each="task : ${board.tasks}">
+                   <input type="checkbox" th:checked="${task.isFinished() eq true}"> <th:block th:text="'할일 : '+ ${task.content() + '   ||   참여자 :'  + task.worker()}"/>
+                </div>
             </div>
-            <div class="card-body">
-                <p th:text="${board.content}">콘텐츠</p>
-            </div>
-        </div>
-        <a href="/board" class="btn btn-secondary">목록으로</a>
-        <a th:href="@{/board/{id}/update(id=${board.id})}" th:method="get" class="btn btn-primary">수정</a>
-        <a th:href="@{/board/{id}/delete(id=${board.id})}" th:method="get" class="btn btn-danger">삭제</a>
+            <a href="/board" class="btn btn-secondary">목록으로</a>
+            <button class="btn btn-primary" id="update" type="button" th:if="${board.userInfo().id() eq userId}">수정</button>
+            <button class="btn btn-danger" id="delete" type="button" th:if="${board.userInfo().id() eq userId}">삭제</button>
+        </form>
     </main>
     <footer>
         &copy; 2023

--- a/proejct/src/main/resources/templates/index.html
+++ b/proejct/src/main/resources/templates/index.html
@@ -219,20 +219,16 @@
                         <!-- Dropdown - User Information -->
                         <div class="dropdown-menu dropdown-menu-right shadow animated--grow-in"
                              aria-labelledby="userDropdown">
-                            <a class="dropdown-item" href="#">
+
+                            <!-- 타임리프로 for each -->
+
+                            <a class="dropdown-item" href="#" style="padding:.15rem 1.0rem">
                                 <i class="fas fa-user fa-sm fa-fw mr-2 text-gray-400"></i>
-                                Profile
+                                Profile <button type="button" class="btn btn-danger" name="delFriend(id)" style="width: 5px; height: 30px; font-size: small; text-align: left; margin-inline: 10%; padding-right: 15%; margin-left: 30px;">X</button>
                             </a>
-                            <a class="dropdown-item" href="#">
-                                <i class="fas fa-cogs fa-sm fa-fw mr-2 text-gray-400"></i>
-                                Settings
-                            </a>
-                            <a class="dropdown-item" href="#">
-                                <i class="fas fa-list fa-sm fa-fw mr-2 text-gray-400"></i>
-                                Activity Log
-                            </a>
+
                             <div class="dropdown-divider"></div>
-                            <a class="dropdown-item" href="/login" data-toggle="modal" data-target="#logoutModal">
+                            <a class="dropdown-item" href="/login" data-toggle="modal" data-target="#logoutModal"  style="padding:.15rem 1.0rem">
                                 <i class="fas fa-sign-out-alt fa-sm fa-fw mr-2 text-gray-400"></i>
                                 Logout
                             </a>

--- a/proejct/src/main/resources/templates/tables.html
+++ b/proejct/src/main/resources/templates/tables.html
@@ -393,20 +393,24 @@
                                 </tr>
                                 <!--                                </thead>-->
                                 <!--                                <tbody>-->
-                                <script th:inline="javascript">
-                                    function redirectToBoard(id) {
-                                        window.location.href = '/board/' + id;
-                                    }
-                                </script>
+                                <th:block th:if="${#strings.isEmpty(boards)}">
+                                    <tr> <td colspan="5">조회 된 결과가 없습니다.</td> </tr>
+                                </th:block>
+                                <th:block th:if="${not #strings.isEmpty(boards)}">
+                                    <script th:inline="javascript">
+                                        function redirectToBoard(id) {
+                                            window.location.href = '/board/' + id;
+                                        }
+                                    </script>
+                                  <tr th:each="board : ${boards}" th:onclick="'javascript:redirectToBoard(' + ${board.id} + ')'">
+                                        <td th:text="${board.id}">id</td>
+                                        <td th:text="${board.title}">title</td>
+                                        <td th:text="${board.userInfo.name}">host</td>
+                                        <td th:text="${board.content}">content</td>
+                                        <td th:text="${#temporals.format(board.createdAt(), 'yyyy-MM-dd HH:mm')}">등록일</td>
+                                    </tr>
+                                </th:block>
 
-                                <tr th:each="board : ${boards}"
-                                    th:onclick="'javascript:redirectToBoard(' + ${board.id} + ')'">
-                                    <td th:text="${board.id}">id</td>
-                                    <td th:text="${board.title}">title</td>
-                                    <td th:text="${board.userInfo.name}">host</td>
-                                    <td th:text="${board.content}">content</td>
-                                    <td th:text="${#temporals.format(board.createdAt(), 'yyyy-MM-dd HH:mm')}">등록일</td>
-                                </tr>
                             </table>
                         </div>
                     </div>


### PR DESCRIPTION
## 작업 내용

[√] 게시글 조회 (목록) :: 건수가 없을경우 표시 처리가 미흡하여 해당 부분 코드 추가했습니다.
[√] 게시글 상세 :: 게시글에 해당하는 할일 목록도 나오도록 하였고 작성자와 로그인 사용자의 ID가 같을 경우 수정-삭제 버튼이 보이도록 했습니다.
[√] 게시글 삭제 :: restfulAPI에 호환되도록 deletemapping를 사용하여 삭제하도록 하였고, 삭제 후 게시글 목록 화면으로 이동합니다.

## 참고 사항

<br>jquery의 경우 3.7.1버전 cdn을 사용했습니다<br>

## 관련 이슈

- Close #71 
