### PR TITLE
[FEAT] 친구 신청 알림 - 수락, 거절 기능

### DIFF
--- a/src/main/java/org/fastcampus/proejct/notification/controller/NotificationRestController.java
+++ b/src/main/java/org/fastcampus/proejct/notification/controller/NotificationRestController.java
@@ -48,6 +48,15 @@ public class NotificationRestController {
                 .build();
     }
 
+    @DeleteMapping("/{senderId}/delete/{receiverId}")
+    public void followdeleteNotify(
+            @PathVariable Long senderId,
+            @PathVariable Long receiverId
+    ) {
+        notificationService.deleteFollowNotices(senderId, receiverId);
+    }
+
+
     @DeleteMapping("/{userId}/deleteAll")
     public void deleteNotifications(
             @PathVariable Long userId

--- a/src/main/java/org/fastcampus/proejct/notification/db/repository/NotificationRepository.java
+++ b/src/main/java/org/fastcampus/proejct/notification/db/repository/NotificationRepository.java
@@ -16,4 +16,9 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Modifying
     @Query("UPDATE Notification n SET n.visible = true WHERE n.receiverId = :receiverId")
     void visibleNotification(@Param("receiverId") Long receiverId);
+
+    @Modifying
+    @Query("DELETE FROM Notification n WHERE n.senderId = :senderId AND n.receiverId = :receiverId AND n.type = 'follow'")
+    void deleteFollowNotify(@Param("senderId") Long senderId, @Param("receiverId") Long receiverId);
+
 }

--- a/src/main/java/org/fastcampus/proejct/notification/service/NotificationService.java
+++ b/src/main/java/org/fastcampus/proejct/notification/service/NotificationService.java
@@ -109,6 +109,10 @@ public class NotificationService {
         notificationRepository.visibleNotification(userId);
     }
 
+    public void deleteFollowNotices(Long senderId, Long receiverId) {
+        notificationRepository.deleteFollowNotify(senderId, receiverId);
+    }
+
     public NotificationDto getNotice(Long notificationId, Long userId) {
         return NotificationDto.from(notificationRepository.findByIdAndReceiverId(notificationId, userId));
     }

--- a/src/main/resources/templates/top.html
+++ b/src/main/resources/templates/top.html
@@ -92,8 +92,11 @@
 
 <!--버튼 추가 -->
                             <div th:if="${notify.getType() eq 'follow'}" class="ml-auto">
-                                <button type="button" class="btn btn-primary">수락</button>
-                                <button type="button" class="btn btn-secondary">거절</button>
+
+                                <button type="button" class="btn btn-primary" th:data-id="${notify.getSenderId()}" onclick="acceptNotification(this)">수락</button>
+                                <button type="button" class="btn btn-secondary" th:data-id="${notify.getSenderId()}" onclick="rejectNotification(this)">거절</button>
+<!--                                <button type="button" class="btn btn-primary">수락</button>-->
+<!--                                <button type="button" class="btn btn-secondary">거절</button>-->
 
 <!--                                <button class="btn btn-sm btn-danger" data-toggle="modal" data-target="#DeleteModal"-->
 <!--                                        th:attr="data-following-id=${friend.id()}" onclick="openDeleteModal(this)">수락</button>-->
@@ -254,6 +257,77 @@
             </div>
         </div>
     </div>
+
+    <script th:inline="javascript">
+        function acceptNotification(button) {
+            var notificationId = button.getAttribute('data-id');
+            // 여기서 알림 수락 처리를 위한 동작 수행
+            // notificationId를 이용하여 필요한 작업 수행
+            console.log("add follower id : " + userId);
+            console.log("add following id : " + notificationId);
+            $.ajax({
+                url: '/follow/' + userId + '/send/' + notificationId,
+                type: 'POST',
+                success: function (response) {
+                    // 삭제 성공 시 모달 닫기 등 추가 동작 수행
+                    console.log(this.url);
+
+                    //성공 시 알림도 삭제
+                    $.ajax({
+                        url: '/notification/' + notificationId + '/delete/' + userId,
+                        type: 'DELETE',
+                        success: function (deletealarmresponse) {
+                            // 삭제 성공 시 모달 닫기 등 추가 동작 수행
+                            console.log(this.url);
+                            $('#rejectNotification').modal('hide');
+                            // 추가 동작을 위한 코드 작성
+                            console.log(deletealarmresponse);
+                        },
+                        error: function (xhr, status, error) {
+                            // 삭제 실패 시 에러 처리
+                            console.error(deletealarmerror);
+                        }
+                    });
+
+                    $('#acceptNotification').modal('hide');
+                    // 삭제 성공 알림창
+                    alert('추가되었습니다.');
+                    // 추가 동작을 위한 코드 작성
+                    console.log(response);
+                },
+                error: function (xhr, status, error) {
+                    // 삭제 실패 시 에러 처리
+                    console.error(error);
+                }
+            });
+        }
+
+        function rejectNotification(button) {
+            var notificationId = button.getAttribute('data-id');
+            // 여기서 알림 거절 처리를 위한 동작 수행
+            // notificationId를 이용하여 필요한 작업 수행
+            console.log("sender id : " + notificationId);
+            console.log("receiver id : " + userId);
+            $.ajax({
+                url: '/notification/' + notificationId + '/delete/' + userId,
+                type: 'DELETE',
+                success: function (response) {
+                    // 삭제 성공 시 모달 닫기 등 추가 동작 수행
+                    console.log(this.url);
+                    $('#rejectNotification').modal('hide');
+                    // 삭제 성공 알림창
+                    alert('거절되었습니다.');
+                    // 추가 동작을 위한 코드 작성
+                    console.log(response);
+                },
+                error: function (xhr, status, error) {
+                    // 삭제 실패 시 에러 처리
+                    console.error(error);
+                }
+            });
+
+        }
+    </script>
     <script>
         function deleteAllNotification(userId) {
             console.log("delete user id : " + userId);


### PR DESCRIPTION
## 작업 내용

여러 타입의 알림 중에 친구 신청 알림만 버튼 생성
수락버튼 누르면 친구 추가 됨과 동시에 알림 삭제(해당 친구 신청 알림)
거절 버튼 누르면 알림 삭제(해당 친구 신청 알림)

## 참고 사항

- 친구 신청이 중복으로 들어오는 것을 방지한다는 전제하에 진행된 기능으로 
알림 자체의 id 값이 아닌 senderId, receiverId, type  조건으로 걸어서 삭제
- 알림 목록에 친구신청 이름이 아닌 ID 로 현재 나옴 -> 추후 구현 예정

## 관련 이슈

- Close #138 
